### PR TITLE
Replace OpenAI with local Qwen2.5-3B model for mood extraction

### DIFF
--- a/cinemood-backend/.gitignore
+++ b/cinemood-backend/.gitignore
@@ -1,3 +1,4 @@
 venv/
 __pycache__/
 .env
+.DS_Store

--- a/cinemood-backend/app/nlp.py
+++ b/cinemood-backend/app/nlp.py
@@ -1,29 +1,46 @@
-from openai import OpenAI
-from app.config import OPENAI_API_KEY
+# from openai import OpenAI
+# from app.config import OPENAI_API_KEY
 
-client = OpenAI(api_key=OPENAI_API_KEY)
+# client = OpenAI(api_key=OPENAI_API_KEY)
+
+from transformers import pipeline
+import re
+import ast
+
+def _extract_list_from_output(output: str) -> list[str]:
+    """Private helper function to extract a list from model output."""
+    matches = re.finditer(r"\[.*?\]", output, re.DOTALL)
+    matches_list = list(matches)
+    if matches_list:
+        try:
+            tags = ast.literal_eval(matches_list[-1].group(0))
+            if isinstance(tags, list) and all(isinstance(tag, str) for tag in tags):
+                return tags
+        except Exception as e:
+            print("Error parsing list:", e)
+    return ["sad", "hopeful"]
 
 def extract_mood_tags(text: str) -> list[str]:
+    """
+    Extract emotional and thematic keywords from the input text using a local language model.
+    
+    Args:
+        text (str): The input text to analyze
+        
+    Returns:
+        list[str]: A list of 2-4 emotional or thematic keywords
+    """
+    # Initialize the model only when the function is called
+    model_name = "Qwen/Qwen2.5-3B-Instruct"
+    generator = pipeline("text-generation", model=model_name, max_new_tokens=100, truncation=True)
+    
     prompt = (
         f"The user is feeling sad and wrote: \"{text}\"\n"
         "Extract 2 to 4 simple emotional or thematic keywords that describe why they're feeling this way. "
-        "Return the keywords as a Python list of strings. For example: ['heartbreak', 'loneliness', 'healing']"
+        "Return ONLY a Python list of strings containing the keywords."
     )
 
-    response = client.chat.completions.create(
-        model="gpt-3.5-turbo",
-        messages=[{"role": "user", "content": prompt}],
-        temperature=0.7,
-    )
+    response = generator(prompt, num_return_sequences=1)
+    raw_output = response[0]['generated_text']
 
-    raw_output = response.choices[0].message.content
-
-    try:
-        tags = eval(raw_output)
-        if isinstance(tags, list) and all(isinstance(tag, str) for tag in tags):
-            return tags
-    except Exception as e:
-        print("Error parsing response from OpenAI:", e)
-        print("Raw output was:", raw_output)
-
-    return ["sad", "hopeful"]
+    return _extract_list_from_output(raw_output)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,7 @@ uvicorn
 openai
 httpx
 python-dotenv
+transformers
+torch
+accelerate
+sentencepiece


### PR DESCRIPTION
## Changes
- Replaced OpenAI API with locally hosted Qwen2.5-3B-Instruct model for mood extraction
- Implemented robust post-processing to extract mood tags from model output
- Added proper error handling with fallback tags
- Structured code as importable module with private helper functions
- Added required dependencies to requirements.txt

## Rationale
- Reduce API costs and latency by using a local model
- Improve reliability by removing external API dependency
- Maintain similar quality of mood extraction with a smaller model
- Better code organization for integration with other components

## Testing
The changes have been tested with various emotional inputs and the model successfully extracts relevant mood tags. For example:
- Input: "I'm feeling sad and lonely today" → Tags: ['sad', 'lonely']
- Input: "I'm feeling overwhelmed and anxious about my upcoming presentation" → Tags: ['anxiety', 'overwhelm']

## Dependencies Added
- transformers
- torch
- accelerate
- sentencepiece